### PR TITLE
ログイン機能

### DIFF
--- a/html/login-redirect.html
+++ b/html/login-redirect.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=400">
+  <meta name="format-detection" content="telephone=no">
+  <meta name="robots" content="noindex, nofollow">
+  <title>Blue Symfony</title>
+  <meta content="LTL" property="og:title">
+  <meta content="https://imastodon.blue/sp/" property="og:image">
+  <meta content="https://imastodon.blue/sp/index.html" property="og:url">
+  <meta content="ja_JP" property="og:locale">
+  <link rel="stylesheet" href="style.css">
+
+</head>
+
+<body>
+  <div id="bs-app">
+  </div>
+  <script src="assets/js/login-redirect.js"></script>
+</body>
+
+</html>

--- a/html/login.html
+++ b/html/login.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=400">
+  <meta name="format-detection" content="telephone=no">
+  <meta name="robots" content="noindex, nofollow">
+  <title>Blue Symfony</title>
+  <meta content="LTL" property="og:title">
+  <meta content="https://imastodon.blue/sp/" property="og:image">
+  <meta content="https://imastodon.blue/sp/index.html" property="og:url">
+  <meta content="ja_JP" property="og:locale">
+  <link rel="stylesheet" href="style.css">
+
+</head>
+
+<body>
+  <div id="bs-app">
+    <bs-login></bs-login>
+  </div>
+  <script src="assets/js/login.js"></script>
+</body>
+
+</html>

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "element-ui": "^2.9.1",
     "events": "^3.0.0",
     "express": "^4.16.3",
+    "js-cookie": "^2.2.0",
     "sanitize-html": "^1.19.1",
     "tootjs": "^0.3.0",
     "vue": "^2.6.10"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "author": "YaQ",
   "license": "MIT",
   "devDependencies": {
+    "cookie-parser": "^1.4.4",
     "css-loader": "^3.0.0",
     "pug": "^2.0.3",
     "pug-loader": "^2.4.0",

--- a/server/app.js
+++ b/server/app.js
@@ -13,6 +13,9 @@ var authenticate = (req, res, next) => {
   }
 }
 
+app.get('/login-redirect', (req, res) => {
+  res.sendFile(path.join(__dirname, '../html/login-redirect.html'))
+})
 app.get('/', authenticate, (req, res) => {
   res.sendFile(path.join(__dirname, '../html', '/index.html'))
 })

--- a/server/app.js
+++ b/server/app.js
@@ -1,11 +1,22 @@
 var path = require('path')
 var express = require('express')
+var cookieParser = require('cookie-parser')
 var app = express()
 
-app.get('/', (req, res) => {
+app.use(cookieParser())
+
+var authenticate = (req, res, next) => {
+  if (req.cookies.token) {
+    next()
+  } else {
+    res.sendFile(path.join(__dirname, '../html', '/login.html'))
+  }
+}
+
+app.get('/', authenticate, (req, res) => {
   res.sendFile(path.join(__dirname, '../html', '/index.html'))
 })
-app.get('/tags/:tag', (req, res) => {
+app.get('/tags/:tag', authenticate, (req, res) => {
   res.sendFile(path.join(__dirname, '../html/tags.html'))
 })
 app.get('/style.css', (req, res) => {

--- a/src/common.js
+++ b/src/common.js
@@ -1,11 +1,12 @@
 import * as tootjs from 'tootjs'
 import sanitizeHtml from 'sanitize-html'
 import { EventEmitter } from 'events';
+import * as Cookies from 'js-cookie'
 
 export var config = {
-  "access_token": "---",
+  "access_token": Cookies.get('token'),
   "scope": "read write follow",
-  "host": "==="
+  "host": localStorage.getItem("domain")
 };
 
 export var mastodon = new tootjs.Mastodon(config);

--- a/src/login-redirect.js
+++ b/src/login-redirect.js
@@ -1,0 +1,28 @@
+
+var domain = localStorage.getItem("domain")
+var params = new URLSearchParams(window.location.search.substring(1))
+var code = params.get('code')
+
+var api = `https://${domain}/oauth/token`
+var form = {
+  "grant_type": "authorization_code",
+  "client_id": localStorage.getItem("client_id"),
+  "client_secret": localStorage.getItem("client_secret"),
+  "redirect_uri": `https://${window.location.host}/login-redirect`,
+  "code": code
+}
+var option = {
+  method: "POST",
+  headers: {
+    'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8'
+  },
+  body: Object.keys(form).map(key => key + "=" + encodeURIComponent(form[key])).join("&")
+}
+fetch(api, option)
+  .then(res => res.json())
+  .then(body => {
+    localStorage.removeItem("client_id")
+    localStorage.removeItem("client_secret")
+    document.cookie = `token=${body.access_token}`
+    window.location.href = "/"
+  })

--- a/src/login.js
+++ b/src/login.js
@@ -1,0 +1,11 @@
+import Vue from 'vue'
+import BsLogin from './vue/bs-login.vue'
+import Element from 'element-ui'
+import 'element-ui/lib/theme-chalk/index.css'
+
+Vue.use(Element)
+
+new Vue({
+  el: "#bs-app",
+  components: { BsLogin }
+})

--- a/src/vue/bs-login.vue
+++ b/src/vue/bs-login.vue
@@ -1,0 +1,48 @@
+<template lang="pug">
+  .root
+    form(@submit.prevent="login(hostname)")
+      input(type="text", v-model="hostname")
+      input(type="submit", value="ログイン")
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
+  methods: {
+    login: (domain) => {
+      var clientId = localStorage.getItem("client_id")
+      var clientSecret = localStorage.getItem("client_secret")
+      if (!clientId || !clientSecret) {
+        const api = `https://${domain}/api/v1/apps`
+        const form = {
+          "client_name": "Blue Symfony",
+          "redirect_uris": `https://${window.location.host}/login-redirect`,
+          "scopes": "read write follow"
+        }
+        const option = {
+          method: "POST",
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8'
+          },
+          body: Object.keys(form).map(key => key + "=" + encodeURIComponent(form[key])).join("&")
+        }
+        fetch(api, option)
+          .then(res => res.json())
+          .then(body => {
+            var clientId = body.client_id
+            var clientSecret = body.client_secret
+            localStorage.setItem("client_id", clientId)
+            localStorage.setItem("client_secret", clientSecret)
+            var redirectTo = encodeURIComponent(`https://${window.location.host}/login-redirect`)
+            window.location.href = `https://${domain}/oauth/authorize?client_id=${clientId}&client_secret=${clientSecret}&response_type=code&redirect_uri=${redirectTo}`
+          })
+      } else {
+        var redirectTo = encodeURIComponent(`https://${window.location.host}/login-redirect`)
+            window.location.href = `https://${domain}/oauth/authorize?client_id=${clientId}&client_secret=${clientSecret}&response_type=code&redirect_uri=${redirectTo}`
+      }
+    }
+  }
+})
+</script>
+

--- a/src/vue/bs-login.vue
+++ b/src/vue/bs-login.vue
@@ -11,6 +11,7 @@ import Vue from 'vue'
 export default Vue.extend({
   methods: {
     login: (domain) => {
+      localStorage.setItem("domain", domain)
       var clientId = localStorage.getItem("client_id")
       var clientSecret = localStorage.getItem("client_secret")
       if (!clientId || !clientSecret) {
@@ -39,7 +40,7 @@ export default Vue.extend({
           })
       } else {
         var redirectTo = encodeURIComponent(`https://${window.location.host}/login-redirect`)
-            window.location.href = `https://${domain}/oauth/authorize?client_id=${clientId}&client_secret=${clientSecret}&response_type=code&redirect_uri=${redirectTo}`
+        window.location.href = `https://${domain}/oauth/authorize?client_id=${clientId}&client_secret=${clientSecret}&response_type=code&redirect_uri=${redirectTo}`
       }
     }
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ module.exports = {
   entry: {
       index: './src/index.js',
       login: './src/login.js',
+      'login-redirect' : './src/login-redirect.js',
       tags: './src/tags.js'
   },
   output: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,8 +3,8 @@ const VueLoaderPlugin = require("vue-loader/lib/plugin")
 
 module.exports = {
   entry: {
-  //       index: './src/index.js',
-      index2: './src/index2.js',
+      index: './src/index.js',
+      login: './src/login.js',
       tags: './src/tags.js'
   },
   output: {


### PR DESCRIPTION
# 変更概要
- Cookieにトークンが入ってなければログイン画面に飛ぶように
- ログイン画面の見栄えは特に作り込んでいないので再デザインが必要
- ログイン後のリダイレクト画面を作成

# 現在の制限
どうもmastodonのログインリダイレクト先はSSLでなければならないらしく、Mastodon側の画面でリダイレクトした後に接続エラーが出るのでアドレスバー上でhttpsをhttpに書き換えてやる必要がある。

将来的にはサーバ側をSSL/TLS化する事で解決したいがこの課題ではやらない。

# close
#16