### PR TITLE
一部のライブラリを外部URLから読み込むように

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -12,6 +12,7 @@
   <meta content="https://imastodon.blue/sp/" property="og:image">
   <meta content="https://imastodon.blue/sp/index.html" property="og:url">
   <meta content="ja_JP" property="og:locale">
+  <link rel="stylesheet" href="https://unpkg.com/element-ui/lib/theme-chalk/index.css">
   <link rel="stylesheet" href="style.css">
 
 </head>
@@ -20,6 +21,9 @@
   <div id="bs-app">
     <bs-index></bs-index>
   </div>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/2.2.1/js.cookie.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vue"></script>
+  <script src="https://unpkg.com/element-ui/lib/index.js"></script>
   <script src="assets/js/index.js"></script>
 </body>
 

--- a/html/login.html
+++ b/html/login.html
@@ -12,6 +12,7 @@
   <meta content="https://imastodon.blue/sp/" property="og:image">
   <meta content="https://imastodon.blue/sp/index.html" property="og:url">
   <meta content="ja_JP" property="og:locale">
+  <link rel="stylesheet" href="https://unpkg.com/element-ui/lib/theme-chalk/index.css">
   <link rel="stylesheet" href="style.css">
 
 </head>
@@ -20,6 +21,9 @@
   <div id="bs-app">
     <bs-login></bs-login>
   </div>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/2.2.1/js.cookie.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vue"></script>
+  <script src="https://unpkg.com/element-ui/lib/index.js"></script>
   <script src="assets/js/login.js"></script>
 </body>
 

--- a/html/tags.html
+++ b/html/tags.html
@@ -12,6 +12,7 @@
   <meta content="https://imastodon.blue/sp/" property="og:image">
   <meta content="https://imastodon.blue/sp/index.html" property="og:url">
   <meta content="ja_JP" property="og:locale">
+  <link rel="stylesheet" href="https://unpkg.com/element-ui/lib/theme-chalk/index.css">
   <link rel="stylesheet" href="style.css">
 
 </head>
@@ -20,6 +21,9 @@
   <div id="bs-app">
     <bs-tag></bs-tag>
   </div>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/2.2.1/js.cookie.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/vue"></script>
+  <script src="https://unpkg.com/element-ui/lib/index.js"></script>
   <script src="assets/js/tags.js"></script>
 </body>
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "webpack-dev-server": "^3.1.9"
   },
   "dependencies": {
-    "axios": "^0.18.0",
     "consolidate": "^0.15.1",
     "element-ui": "^2.9.1",
     "events": "^3.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,8 @@
 import Vue from 'vue'
 import BsIndex from './vue/bs-index.vue'
-import Element from 'element-ui'
-import 'element-ui/lib/theme-chalk/index.css'
+import ELEMENT from 'element-ui'
 
-Vue.use(Element)
+Vue.use(ELEMENT)
 
 new Vue({
   el: "#bs-app",

--- a/src/login.js
+++ b/src/login.js
@@ -1,9 +1,8 @@
 import Vue from 'vue'
 import BsLogin from './vue/bs-login.vue'
-import Element from 'element-ui'
-import 'element-ui/lib/theme-chalk/index.css'
+import ELEMENT from 'element-ui'
 
-Vue.use(Element)
+Vue.use(ELEMENT)
 
 new Vue({
   el: "#bs-app",

--- a/src/tags.js
+++ b/src/tags.js
@@ -1,9 +1,8 @@
 import Vue from 'vue'
 import BsTag from './vue/bs-tag.vue'
-import Element from 'element-ui'
-import 'element-ui/lib/theme-chalk/index.css'
+import ELEMENT from 'element-ui'
 
-Vue.use(Element)
+Vue.use(ELEMENT)
 
 new Vue({
   el: "#bs-app",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,11 @@ module.exports = {
     filename: '[name].js',
     path: path.resolve(__dirname, 'assets/js')
   },
+  externals: {
+    vue: "Vue",
+    'element-ui': "ELEMENT",
+    'js-cookie': "Cookies"
+  },
   module: {
     rules: [
       {


### PR DESCRIPTION
従来はVueやElementUIなどのライブラリをWebpackによって一つのJSにコンパイルしていてそのせいでファイルサイズが1MBを越えていた。

今回Webpackの設定を変えた事で出力JSファイルにVueやElementUIを含まないようにしてHTML側で外部のCDNから読み込むようにできた。

最終的に出力のファイルサイズは250KB(約1/4)まで削減できた。

あとこれは備考だがCDNから降ってくるElementUIではexport名が `ELEMENT` になっているのでJS側でもこれに合わせて変更する必要があった。

closes #25 